### PR TITLE
Merge feature/create-dummy-provider into dev

### DIFF
--- a/LibraryTestProject/Program.cs
+++ b/LibraryTestProject/Program.cs
@@ -1,11 +1,17 @@
+using LibraryTestProject.Services.Contracts;
+using LibraryTestProject.Services.Implementations;
+using LibraryTestProject.Services.Models;
 using RedisConfigurationProvider;
 using RedisConfigurationProvider.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddRedisConfiguration();
+builder.Services.Configure<ConfigurationData>(builder.Configuration.GetSection(nameof(ConfigurationData)));
+builder.Services.AddSingleton<IConfigurationTestService, ConfigurationTestService>();
 var app = builder.Build();
 
 app.MapGet("/", () => "Hello World!");
 app.MapGet("/{n}", (int n) => $"Hello World!\n[{string.Join(',',Class1.GetSquares(n))}]");
+app.MapGet("/config", (string key, IConfigurationTestService service) => service.GetResult(key));
 
 app.Run();

--- a/LibraryTestProject/Program.cs
+++ b/LibraryTestProject/Program.cs
@@ -1,6 +1,8 @@
 using RedisConfigurationProvider;
+using RedisConfigurationProvider.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Configuration.AddRedisConfiguration();
 var app = builder.Build();
 
 app.MapGet("/", () => "Hello World!");

--- a/LibraryTestProject/Services/Contracts/IConfigurationTestService.cs
+++ b/LibraryTestProject/Services/Contracts/IConfigurationTestService.cs
@@ -1,0 +1,9 @@
+﻿namespace LibraryTestProject.Services.Contracts
+{
+    public interface IConfigurationTestService
+    {
+
+        string GetResult(string key);
+
+    }
+}

--- a/LibraryTestProject/Services/Implementations/ConfigurationTestService.cs
+++ b/LibraryTestProject/Services/Implementations/ConfigurationTestService.cs
@@ -1,0 +1,26 @@
+﻿using LibraryTestProject.Services.Contracts;
+using LibraryTestProject.Services.Models;
+using Microsoft.Extensions.Options;
+
+namespace LibraryTestProject.Services.Implementations
+{
+    public class ConfigurationTestService : IConfigurationTestService
+    {
+
+        private string Data1 { get; set; }
+        private string Data2 { get; set; }
+
+        public ConfigurationTestService(IOptions<ConfigurationData> data)
+        {
+            Data1 = data.Value.Data1;
+            Data2 = data.Value.Data2;
+        }
+
+        public string GetResult(string key) => key switch
+        {
+            "Data1" => Data1,
+            "Data2" => Data2,
+            _ => "Unknown"
+        };
+    }
+}

--- a/LibraryTestProject/Services/Models/ConfigurationData.cs
+++ b/LibraryTestProject/Services/Models/ConfigurationData.cs
@@ -1,0 +1,10 @@
+﻿namespace LibraryTestProject.Services.Models
+{
+    public class ConfigurationData
+    {
+
+        public string Data1 { get; set; }
+        public string Data2 { get; set; }
+
+    }
+}

--- a/LibraryTestProject/appsettings.json
+++ b/LibraryTestProject/appsettings.json
@@ -8,5 +8,9 @@
   "AllowedHosts": "*",
   "RedisConfigurationProvider": {
     "Key": "TestKey"
+  },
+  "ConfigurationData": {
+    "Data1": "Appsettings1",
+    "Data2": "Appsettings2"
   }
 }

--- a/LibraryTestProject/appsettings.json
+++ b/LibraryTestProject/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "RedisConfigurationProvider": {
+    "Key": "TestKey"
+  }
 }

--- a/RedisConfigurationProvider/Extensions/ConfigurationManagerExtensions.cs
+++ b/RedisConfigurationProvider/Extensions/ConfigurationManagerExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Configuration;
+using RedisConfigurationProvider.Providers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedisConfigurationProvider.Extensions
+{
+    public static class ConfigurationManagerExtensions
+    {
+
+        public static ConfigurationManager AddRedisConfiguration(this ConfigurationManager configurationManager)
+        {
+            var key = configurationManager.GetSection("RedisConfigurationProvider:Key").Value;
+            Console.WriteLine(key);
+            IConfigurationBuilder builder = configurationManager;
+            builder.Add(new RedisConfigurationSource(key));
+            return configurationManager;
+        }
+
+    }
+}

--- a/RedisConfigurationProvider/Providers/RedisConfigurationProvider.cs
+++ b/RedisConfigurationProvider/Providers/RedisConfigurationProvider.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedisConfigurationProvider.Providers
+{
+    public sealed class RedisConfigurationProvider(string? key) : ConfigurationProvider
+    {
+        public override void Load()
+        {
+            base.Load();
+        }
+    }
+}

--- a/RedisConfigurationProvider/Providers/RedisConfigurationProvider.cs
+++ b/RedisConfigurationProvider/Providers/RedisConfigurationProvider.cs
@@ -9,9 +9,16 @@ namespace RedisConfigurationProvider.Providers
 {
     public sealed class RedisConfigurationProvider(string? key) : ConfigurationProvider
     {
+
+        public static Dictionary<string, Dictionary<string, string>> DataSets = new Dictionary<string, Dictionary<string, string>> {
+            { "TestKey" , new Dictionary<string, string>{ { "Data1", "Value1" },  { "Data2", "Value2" } } },
+            { "ProdKey" , new Dictionary<string, string>{ { "Data1", "ProdValue1" },  { "Data2", "ProdValue2" } } }
+        };
+
         public override void Load()
         {
-            base.Load();
+            Dictionary<string, string> dataset = DataSets[key];
+            foreach (var item in dataset) Data.Add(item);
         }
     }
 }

--- a/RedisConfigurationProvider/Providers/RedisConfigurationProvider.cs
+++ b/RedisConfigurationProvider/Providers/RedisConfigurationProvider.cs
@@ -11,8 +11,8 @@ namespace RedisConfigurationProvider.Providers
     {
 
         public static Dictionary<string, Dictionary<string, string>> DataSets = new Dictionary<string, Dictionary<string, string>> {
-            { "TestKey" , new Dictionary<string, string>{ { "Data1", "Value1" },  { "Data2", "Value2" } } },
-            { "ProdKey" , new Dictionary<string, string>{ { "Data1", "ProdValue1" },  { "Data2", "ProdValue2" } } }
+            { "TestKey" , new Dictionary<string, string>{ { "ConfigurationData:Data1", "Value1" },  { "ConfigurationData:Data2", "Value2" } } },
+            { "ProdKey" , new Dictionary<string, string>{ { "ConfigurationData:Data1", "ProdValue1" },  { "ConfigurationData:Data2", "ProdValue2" } } }
         };
 
         public override void Load()

--- a/RedisConfigurationProvider/Providers/RedisConfigurationSource.cs
+++ b/RedisConfigurationProvider/Providers/RedisConfigurationSource.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedisConfigurationProvider.Providers
+{
+    public sealed class RedisConfigurationSource(string? key) : IConfigurationSource
+    {
+        public IConfigurationProvider Build(IConfigurationBuilder builder) => new RedisConfigurationProvider(key);
+    }
+}

--- a/RedisConfigurationProvider/RedisConfigurationProvider.csproj
+++ b/RedisConfigurationProvider/RedisConfigurationProvider.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The dummy provider can now load different configuration from the fixed list of configurations based on the supplied key that if the extension method is used is supplied through the interrim configuration