### PR TITLE
Merging dev into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2025-05-17
+
+### Added
+- Added a options class that now simplifies the loading of the interim configuration
+- Added a new overload of the extension method which accepts an action with the options parameter which is used for overwriting of components of options loaded from interim configuration
+
+### Changed
+- The string that specifies the levels of a key are now overwritable through the options class
+
+### Fixed
+
+
 ## [1.1.0] - 2025-04-28
 Keys in redis can now be nested.
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ After the library is added either
     builder.Configuration.AddRedisConfiguration();
   ```
   has to be called on the configuration builder
+* extension method 
+  ```c#
+    builder.Configuration.AddRedisConfiguration((options)=>{});
+  ```
+  has to be called on the configuration builder where the actions parameters can be used to override the interim configuration
 * or the work it does has to be done manually
 
 The extension method collects the necessary redis connection string components and the key to be used from the interim configuration and adds the redis configuration source to the configuration builder
@@ -126,12 +131,15 @@ The interim configuration when represented in JSON will look like:
   "Port": "1234", // optional defaults to "6379"
   "Username": "username", // optional defaults to "default"
   "Password": "password", // optional defaults to ""
+  "KeyLevelSeparator": "-", // optional defaults to "_"
   "Key": "key"
 },
 ```
 
-The key can take the form of ident[_ident]* where first the key ident is loaded (if the key exists) and then each new _ident is added to the key and the value for that key is loaded(if the key exists)
-This way each new _ident can override some specific part of the configuration.
+The key can take the form of ```ident [keylevelseparator ident]*``` where first the key ident is loaded (if the key exists) and then each new ```keylevelseparator ident``` is added to the key and the value for that key is loaded(if the key exists)
+This way each new ```keylevelseparator ident``` can override some specific part of the configuration.
+
+keylevelseparator is "_" by default but that can be overriden through options
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/RedisConfigurationProvider/Configuration/RedisConfigurationProviderOptions.cs
+++ b/RedisConfigurationProvider/Configuration/RedisConfigurationProviderOptions.cs
@@ -13,7 +13,7 @@ namespace RedisConfigurationProvider.Configuration
         public const string Name = "RedisConfigurationProvider";
 
         public string Url { get; set; } = "localhost";
-        public int Port { get; set; } = 9379;
+        public int Port { get; set; } = 6379;
         public string Username { get; set; } = "default";
         public string Password { get; set; } = "";
         public string Key { get; set; } = "";

--- a/RedisConfigurationProvider/Configuration/RedisConfigurationProviderOptions.cs
+++ b/RedisConfigurationProvider/Configuration/RedisConfigurationProviderOptions.cs
@@ -10,6 +10,7 @@
         public string Username { get; set; } = "default";
         public string Password { get; set; } = "";
         public string Key { get; set; } = "";
+        public string KeyLevelSeparator { get; set; } = "_";
 
     }
 }

--- a/RedisConfigurationProvider/Configuration/RedisConfigurationProviderOptions.cs
+++ b/RedisConfigurationProvider/Configuration/RedisConfigurationProviderOptions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedisConfigurationProvider.Configuration
+{
+    public class RedisConfigurationProviderOptions
+    {
+
+        public const string Name = "RedisConfigurationProvider";
+
+        public string Url { get; set; } = "localhost";
+        public int Port { get; set; } = 9379;
+        public string Username { get; set; } = "default";
+        public string Password { get; set; } = "";
+        public string Key { get; set; } = "";
+
+    }
+}

--- a/RedisConfigurationProvider/Configuration/RedisConfigurationProviderOptions.cs
+++ b/RedisConfigurationProvider/Configuration/RedisConfigurationProviderOptions.cs
@@ -1,11 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace RedisConfigurationProvider.Configuration
+﻿namespace RedisConfigurationProvider.Configuration
 {
     public class RedisConfigurationProviderOptions
     {

--- a/RedisConfigurationProvider/Extensions/ConfigurationManagerExtensions.cs
+++ b/RedisConfigurationProvider/Extensions/ConfigurationManagerExtensions.cs
@@ -15,15 +15,17 @@ namespace RedisConfigurationProvider.Extensions
 
         public static ConfigurationManager AddRedisConfiguration(this ConfigurationManager configurationManager)
         {
-            var config = configurationManager.GetSection(RedisConfigurationProviderOptions.Name).Get<RedisConfigurationProviderOptions>();
-            ConfigurationOptions opts = new ConfigurationOptions()
-            {
-                EndPoints = { { config.Url, config.Port } },
-                User = config.Username,
-                Password = config.Password
-            };
+            var options = configurationManager.GetSection(RedisConfigurationProviderOptions.Name).Get<RedisConfigurationProviderOptions>();
             IConfigurationBuilder builder = configurationManager;
-            builder.Add(new RedisConfigurationSource(opts.ToString(),config.Key));
+            builder.Add(new RedisConfigurationSource(options));
+            return configurationManager;
+        }
+        public static ConfigurationManager AddRedisConfiguration(this ConfigurationManager configurationManager, Action<RedisConfigurationProviderOptions> setupOptions)
+        {
+            IConfigurationBuilder builder = configurationManager;
+            var options = configurationManager.GetSection(RedisConfigurationProviderOptions.Name).Get<RedisConfigurationProviderOptions>();
+            setupOptions(options);
+            builder.Add(new RedisConfigurationSource(options));
             return configurationManager;
         }
 

--- a/RedisConfigurationProvider/Extensions/ConfigurationManagerExtensions.cs
+++ b/RedisConfigurationProvider/Extensions/ConfigurationManagerExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using RedisConfigurationProvider.Configuration;
 using RedisConfigurationProvider.Providers;
 using StackExchange.Redis;
 using System;
@@ -14,19 +15,15 @@ namespace RedisConfigurationProvider.Extensions
 
         public static ConfigurationManager AddRedisConfiguration(this ConfigurationManager configurationManager)
         {
-            var redisUrl = configurationManager.GetSection("RedisConfigurationProvider:Url").Value ?? "localhost";
-            var redisPort = configurationManager.GetSection("RedisConfigurationProvider:Port").Value ?? "6379";
-            var redisUsername = configurationManager.GetSection("RedisConfigurationProvider:Username").Value ?? "default";
-            var redisPassword = configurationManager.GetSection("RedisConfigurationProvider:Password").Value ?? "";
-            var key = configurationManager.GetSection("RedisConfigurationProvider:Key").Value;
+            var config = configurationManager.GetSection(RedisConfigurationProviderOptions.Name).Get<RedisConfigurationProviderOptions>();
             ConfigurationOptions opts = new ConfigurationOptions()
             {
-                EndPoints = { { redisUrl, int.Parse(redisPort) } },
-                User = redisUsername,
-                Password = redisPassword
+                EndPoints = { { config.Url, config.Port } },
+                User = config.Username,
+                Password = config.Password
             };
             IConfigurationBuilder builder = configurationManager;
-            builder.Add(new RedisConfigurationSource(opts.ToString(),key));
+            builder.Add(new RedisConfigurationSource(opts.ToString(),config.Key));
             return configurationManager;
         }
 

--- a/RedisConfigurationProvider/Extensions/ConfigurationManagerExtensions.cs
+++ b/RedisConfigurationProvider/Extensions/ConfigurationManagerExtensions.cs
@@ -1,12 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using RedisConfigurationProvider.Configuration;
 using RedisConfigurationProvider.Providers;
-using StackExchange.Redis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RedisConfigurationProvider.Extensions
 {

--- a/RedisConfigurationProvider/Providers/RedisConfigurationProvider.cs
+++ b/RedisConfigurationProvider/Providers/RedisConfigurationProvider.cs
@@ -1,12 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using StackExchange.Redis;
 using System.Text.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Channels;
-using System.Threading.Tasks;
+using RedisConfigurationProvider.Configuration;
 
 namespace RedisConfigurationProvider.Providers
 {
@@ -17,11 +12,17 @@ namespace RedisConfigurationProvider.Providers
         private IDatabase _db;
         private string _key;
 
-        public RedisConfigurationProvider(string? connectionString, string key)
+        public RedisConfigurationProvider(RedisConfigurationProviderOptions options)
         {
-            var mux = ConnectionMultiplexer.Connect(connectionString);
+            ConfigurationOptions configOptions = new ConfigurationOptions()
+            {
+                EndPoints = { { options.Url, options.Port } },
+                User = options.Username,
+                Password = options.Password
+            };
+            var mux = ConnectionMultiplexer.Connect(configOptions.ToString());
             _db = mux.GetDatabase();
-            _key = key;
+            _key = options.Key;
         }
 
         public override void Load()

--- a/RedisConfigurationProvider/Providers/RedisConfigurationProvider.cs
+++ b/RedisConfigurationProvider/Providers/RedisConfigurationProvider.cs
@@ -8,7 +8,7 @@ namespace RedisConfigurationProvider.Providers
     public sealed class RedisConfigurationProvider : ConfigurationProvider
     {
 
-        private const char NestingSeparator = '_';
+        private string _keyLevelSeparator;
         private IDatabase _db;
         private string _key;
 
@@ -23,11 +23,12 @@ namespace RedisConfigurationProvider.Providers
             var mux = ConnectionMultiplexer.Connect(configOptions.ToString());
             _db = mux.GetDatabase();
             _key = options.Key;
+            _keyLevelSeparator = options.KeyLevelSeparator;
         }
 
         public override void Load()
         {
-            foreach(var key in GetNestedKeys(_key))
+            foreach(var key in GetNestedKeys(_key, _keyLevelSeparator))
             {
                 if (!_db.KeyExists(key)) continue;
                 var redisResult = _db.StringGet(key).ToString();
@@ -39,13 +40,13 @@ namespace RedisConfigurationProvider.Providers
             }
         }
 
-        private static List<string> GetNestedKeys(string key)
+        private static List<string> GetNestedKeys(string key, string keyLevelSeparator)
         {
             var result = new List<string>();
-            var segments = key.Split(NestingSeparator);
+            var segments = key.Split(keyLevelSeparator);
             for (var i = 1; i <= segments.Length; i++)
             {
-                result.Add(string.Join('_', segments[0..i]));
+                result.Add(string.Join(keyLevelSeparator, segments[0..i]));
             }
             return result;
         }

--- a/RedisConfigurationProvider/Providers/RedisConfigurationSource.cs
+++ b/RedisConfigurationProvider/Providers/RedisConfigurationSource.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using RedisConfigurationProvider.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,8 +8,8 @@ using System.Threading.Tasks;
 
 namespace RedisConfigurationProvider.Providers
 {
-    public sealed class RedisConfigurationSource(string connectionString, string key) : IConfigurationSource
+    public sealed class RedisConfigurationSource(RedisConfigurationProviderOptions options) : IConfigurationSource
     {
-        public IConfigurationProvider Build(IConfigurationBuilder builder) => new RedisConfigurationProvider(connectionString, key);
+        public IConfigurationProvider Build(IConfigurationBuilder builder) => new RedisConfigurationProvider(options);
     }
 }

--- a/RedisConfigurationProvider/Providers/RedisConfigurationSource.cs
+++ b/RedisConfigurationProvider/Providers/RedisConfigurationSource.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
 using RedisConfigurationProvider.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RedisConfigurationProvider.Providers
 {

--- a/RedisConfigurationProvider/RedisConfigurationProvider.csproj
+++ b/RedisConfigurationProvider/RedisConfigurationProvider.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.5" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.31" />
   </ItemGroup>
 

--- a/RedisConfigurationProvider/RedisConfigurationProvider.csproj
+++ b/RedisConfigurationProvider/RedisConfigurationProvider.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <PackageId>MilanAkik.RedisConfigurationProvider</PackageId>
   </PropertyGroup>
 


### PR DESCRIPTION
Added the options class that represents the interim configuration that now contains also the key level separator which sets the string used between levels of the key
The new option can be used in the extension method overload by passing an action that changes the option object
Closes #26